### PR TITLE
fix: #9 Build fixed

### DIFF
--- a/examples/api_examples/auth/Dockerfile
+++ b/examples/api_examples/auth/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:22-alpine
 RUN apk --no-cache add \
     bash \
     g++ \

--- a/examples/api_examples/auth/package.json
+++ b/examples/api_examples/auth/package.json
@@ -20,7 +20,7 @@
 		"jsonwebtoken": "^8.5.1",
 		"knex": "^2.3.0",
 		"node-rdkafka": "^2.14.0",
-		"objection": "^2.2.15",
+		"objection": "^3.1.5",
 		"pg": "^8.5.1",
 		"winston": "^3.8.1"
 	}

--- a/examples/api_examples/docker-compose.yml
+++ b/examples/api_examples/docker-compose.yml
@@ -125,7 +125,7 @@ services:
 
 
   init-kafka:
-    image: bitnami/kafka:latest
+    image: apache/kafka:4.3.1
     entrypoint: /bin/bash
     networks:
       - shared_network
@@ -137,7 +137,7 @@ services:
 
 
   kafka:
-    image: docker.io/bitnami/kafka:latest
+    image: apache/kafka:4.3.1
     container_name: kafka
     ports:
       - "9092:9092"

--- a/examples/api_examples/final/Dockerfile
+++ b/examples/api_examples/final/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:22-alpine
 RUN apk --no-cache add \
     bash \
     g++ \

--- a/examples/api_examples/intermediate/Dockerfile
+++ b/examples/api_examples/intermediate/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:22-alpine
 RUN apk --no-cache add \
     bash \
     g++ \

--- a/examples/api_examples/notification/Dockerfile
+++ b/examples/api_examples/notification/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:22-alpine
 RUN apk --no-cache add \
     bash \
     g++ \


### PR DESCRIPTION
`make api_examples` was failing at the compose step. Fixing each error
surfaced the next; all of them together:

- updated node version to 22 in a few Dockerfiles
- updated objection version to ^3.1.5 in packages.json
- updated kafka link in compose file

`make api_examples` completes cleanly after these.

Fixes https://github.com/venturenox/sagawise/issues/9